### PR TITLE
Add an option to ignore friend ranks.

### DIFF
--- a/src/main/java/com/clanrosterhelper/ClanRosterHelperConfig.java
+++ b/src/main/java/com/clanrosterhelper/ClanRosterHelperConfig.java
@@ -49,4 +49,14 @@ public interface ClanRosterHelperConfig extends Config {
     default String getDataUrl() {
         return "";
     }
+
+    @ConfigItem(
+            position = 2,
+            keyName = "ignoreFriendRank",
+            name = "Ignore friend rank",
+            description = "Don't show changes to friend ranks"
+    )
+    default boolean ignoreFriendRank() {
+        return false;
+    }
 }

--- a/src/main/java/com/clanrosterhelper/ClanRosterHelperOverlay.java
+++ b/src/main/java/com/clanrosterhelper/ClanRosterHelperOverlay.java
@@ -49,6 +49,9 @@ public class ClanRosterHelperOverlay extends Overlay {
     private final PanelComponent panelComponent;
 
     @Inject
+    private ClanRosterHelperConfig config;
+
+    @Inject
     public ClanRosterHelperOverlay(ClanRosterHelperPlugin plugin) {
         super(plugin);
         setPosition(OverlayPosition.BOTTOM_LEFT);
@@ -155,7 +158,15 @@ public class ClanRosterHelperOverlay extends Overlay {
 
             //If they are not in the extract, they should be removed.
             if (match == null) {
-                drawMember("'" + clanMember.getRSN() + "':", "Remove Friend");
+                if (config.ignoreFriendRank()) {
+                    if (ranksMatch(clanMember.getRank(), "friend"))
+                        continue;
+                    if (ranksMatch(clanMember.getRank(), "not ranked"))
+                        continue;
+                    drawMember("'" + clanMember.getRSN() + "':", "Remove rank");
+                } else {
+                    drawMember("'" + clanMember.getRSN() + "':", "Remove Friend");
+                }
             }
         }
     }

--- a/src/main/java/com/clanrosterhelper/ClanRosterHelperPlugin.java
+++ b/src/main/java/com/clanrosterhelper/ClanRosterHelperPlugin.java
@@ -221,8 +221,15 @@ public class ClanRosterHelperPlugin extends Plugin {
                     }
 
                 Color highlight;
+
                 if (expectedRank.equals("Not in clan")) {
-                    if (menuRank.equals(currentRank)) {
+                    if (menuRank.equals("Not ranked")) {
+                        if (menuRank.equals(currentRank)) {
+                            highlight = Color.GREEN;
+                        } else {
+                            highlight = Color.YELLOW;
+                        }
+                    } else if (menuRank.equals(currentRank)) {
                         highlight = Color.RED;
                     } else {
                         highlight = Color.BLACK;
@@ -339,7 +346,7 @@ public class ClanRosterHelperPlugin extends Plugin {
                     }
 
                 Color highlight;
-                if(expectedRank.equals("Not in clan")) {
+                if(expectedRank.equals("Not in clan") && currentRank.equals("Not ranked")) {
                     highlight = Color.BLACK;
                 } else if(expectedRank.equals(currentRank)) {
                     highlight = Color.GREEN;


### PR DESCRIPTION
The motivation behind this are clan chats where the owner wants to use their friends list freely without this plugin becoming practically unusable unless everyone on their friends list is added to the clan roster with an appropriate rank.

![image](https://user-images.githubusercontent.com/831317/109454776-47c78900-7a55-11eb-96c2-cb744db8f742.png)
With "Ignore friend rank" turned on, the overlay won't display the "Remove friend" message for players that are missing from the clan coster JSON. For cases where the user is missing from the roster but currently has a rank in-game, "Remove rank" is displayed instead.
**There will be no more of this madness**:
![image](https://user-images.githubusercontent.com/831317/109454755-38e0d680-7a55-11eb-822f-cf343beb494e.png)

In addition I've changed the colors for the Chat Setup panel slightly to play nicer with changing people to "Not ranked" instead of removing them from the friends list.
![image](https://user-images.githubusercontent.com/831317/109455295-99bcde80-7a56-11eb-8ec7-637dd09ddb26.png)
